### PR TITLE
Update getting_started_command_line.rst

### DIFF
--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -133,7 +133,7 @@ to your docker command to map a local USB device. Docker on Mac will not be able
 
 .. code-block:: bash
 
-    docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it esphome/esphome run livingroom.yaml
+    docker run --rm --privileged -v "${PWD}":/config --device=/dev/ttyUSB0 -it esphome/esphome run livingroom.yaml
 
 Now when you go to the Home Assistant "Integrations" screen (under "Configuration" panel), you
 should see the ESPHome device show up in the discovered section (although this can take up to 5 minutes).


### PR DESCRIPTION
Added the --privileged docker flag to https://esphome.io/guides/getting_started_command_line.html

## Description:
Missing flag in howto guide was causing PlatformIO to fail to build the project.

**Related issue (if applicable):** fixes 
https://github.com/esphome/issues/issues/3700
https://github.com/esphome/issues/issues/3929


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
